### PR TITLE
Insert CodeMirror into Modal (Having a code near an answer helps to understand explanation better)

### DIFF
--- a/client/components/Modal.tsx
+++ b/client/components/Modal.tsx
@@ -5,6 +5,7 @@ import styled, { keyframes } from "styled-components";
 import { useSpring, animated, config } from "react-spring";
 import { QuestionContext } from "./Question";
 import Button from "./buttons/Button";
+import CodeMirror from "./CodeMirror";
 import { getStyles } from "../utils/getStyles";
 
 export const Modal = () => {
@@ -22,6 +23,7 @@ export const Modal = () => {
 
   return (
     <StyledModal style={style}>
+      <CodeMirror />
       <Answer>{correctAnswer.text || ""}</Answer>
       <Explanation>{question.explanation}</Explanation>
       <Link href={`/question/${parseInt(question.id) + 1}`}>


### PR DESCRIPTION
Hello Lydia

I think it would be great to have a question's code in modal window with an answer and explanation. Having a code before eyes helps to understand explanation better.
Currently, If I want to check code of the question, I can't just close modal. I need to open a list with questions and choose the question once again.

<img width="1240" alt="image" src="https://user-images.githubusercontent.com/66977985/209327985-622af877-b817-4104-9153-12d4543caf27.png">

Please, consider a suggestion.
Thank you in advance!